### PR TITLE
added: missing symfony/console dev dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
             "homepage": "http://caseymclaughlin.com",
             "role":     "Developer"
         }
-    ],    
+    ],
     "license": "MIT",
     "require": {
         "php": ">=5.4.0"
@@ -19,7 +19,8 @@
     "require-dev": {
         "guzzlehttp/guzzle": "~5.0",
         "phpunit/phpunit":   "~4.0",
-        "mockery/mockery":   "~0.9"
+        "mockery/mockery":   "~0.9",
+        "symfony/console": "~2.5"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Hi,

The symfony/console component is missing from the dev-require dependencies.
I've added it to composer.json.
