### PR TITLE
Stop iteration at the end of a record list

### DIFF
--- a/src/Phpoaipmh/RecordIterator.php
+++ b/src/Phpoaipmh/RecordIterator.php
@@ -220,6 +220,9 @@ class RecordIterator implements \Iterator
                 $t = $resp->$verb->resumptionToken['expirationDate'];
                 $this->expireDate = \DateTime::createFromFormat(\DateTime::ISO8601, $t);
             }
+        } else {
+            //Unset the resumption token when we're at the end of the list
+            $this->resumptionToken = null;
         }
 
         //Return a count


### PR DESCRIPTION
When the end of a record list is reached, the resumption token is not being reset. Because of that, the iterator will fetch the last page of records over and over again.