### PR TITLE
HTTP status codes different than 200 can throw OaipmhException

### DIFF
--- a/src/Phpoaipmh/Exception/HttpException.php
+++ b/src/Phpoaipmh/Exception/HttpException.php
@@ -25,5 +25,17 @@ namespace Phpoaipmh\Exception;
  */
 class HttpException extends BaseOaipmhException
 {
-    /* pass */
+    private $body;
+
+    public function __construct($responseBody, $message, $code = 0, \Exception $previous = null) {
+        $this->body = $responseBody;
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @return string
+     */
+    public function getBody() {
+        return $this->body;
+    }
 }

--- a/src/Phpoaipmh/Exception/OaipmhException.php
+++ b/src/Phpoaipmh/Exception/OaipmhException.php
@@ -42,4 +42,8 @@ class OaipmhException extends BaseOaipmhException
         $refl = new \ReflectionClass($this);
         return $refl->getShortName() . ": [{$this->code}]: ({$this->oaiErrorCode}) {$this->message}";
     }
+
+    public function getOaiErrorCode() {
+        return $this->oaiErrorCode;
+    }
 }

--- a/src/Phpoaipmh/HttpAdapter/CurlAdapter.php
+++ b/src/Phpoaipmh/HttpAdapter/CurlAdapter.php
@@ -72,9 +72,9 @@ class CurlAdapter implements HttpAdapterInterface
         $httpCode = (string) $info->http_code;
         if ($httpCode{0} != '2') {
             $msg = sprintf('HTTP Request Failed (code %s): %s', $info->http_code, $resp);
-            throw new HttpException($msg);
+            throw new HttpException($resp, $msg, $httpCode);
         } elseif (strlen(trim($resp)) == 0) {
-            throw new HttpException('HTTP Response Empty');
+            throw new HttpException($resp, 'HTTP Response Empty');
         }
 
         return $resp;

--- a/src/Phpoaipmh/HttpAdapter/GuzzleAdapter.php
+++ b/src/Phpoaipmh/HttpAdapter/GuzzleAdapter.php
@@ -3,7 +3,7 @@
 namespace Phpoaipmh\HttpAdapter;
 
 use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\Exception\TransferException as GuzzleException;
+use GuzzleHttp\Exception\RequestException as GuzzleException;
 use Phpoaipmh\Exception\HttpException;
 
 /**
@@ -58,7 +58,8 @@ class GuzzleAdapter implements HttpAdapterInterface
 
             return (string) $resp->getBody();
         } catch (GuzzleException $e) {
-            throw new HttpException($e->getMessage(), $e->getCode(), $e);
+            $response = $e->getResponse();
+            throw new HttpException($response ? $response->getBody() : null, $e->getMessage(), $e->getCode(), $e);
         }
     }
 }


### PR DESCRIPTION
When an OAI-PMH error is returned with an HTTP status code different than 200, the library throws an HttpException instead of a more meaningful OaipmhException. The pull request fixes this behaviour by also checking the response body of an HttpException for OAI-PMH errors.