### PR TITLE
Changed datetime format

### DIFF
--- a/src/Phpoaipmh/Granularity.php
+++ b/src/Phpoaipmh/Granularity.php
@@ -40,7 +40,7 @@ class Granularity
     {
         $phpFormats = array(
             self::DATE => "Y-m-d",
-            self::DATE_AND_TIME => \DateTime::ISO8601,
+            self::DATE_AND_TIME => 'Y-m-d\TH:i:s\Z',
         );
         $phpFormat = $phpFormats[$format];
 

--- a/tests/Phpoaipmh/GranularityTest.php
+++ b/tests/Phpoaipmh/GranularityTest.php
@@ -42,7 +42,7 @@ class GranularityTest extends PHPUnit_Framework_TestCase
     {
         return array(
             array(Granularity::DATE, "2015-02-01"),
-            array(Granularity::DATE_AND_TIME, "2015-02-01T12:15:30+0000"),
+            array(Granularity::DATE_AND_TIME, "2015-02-01T12:15:30Z"),
         );
     }
 }


### PR DESCRIPTION
The DateTime::ISO8601 format isn't what some OAI-PMH APIs are expecting.

Before: `2015-02-01T12:15:30+0000`
Changed to: `2015-02-01T12:15:30Z`

By specification only the second format (with tailing Z) is allowed, but some APIs seem to also accept the previous format. I think we should go with the one compatible to specification.

Still unclear: How to handle time zones? Since the Z indicates UTC time, the datetime object would need to be converted to UTC. On the other side, is this what users expect?