### PR TITLE
Fixed 'until' BUG

### DIFF
--- a/src/Phpoaipmh/Endpoint.php
+++ b/src/Phpoaipmh/Endpoint.php
@@ -195,7 +195,7 @@ class Endpoint
 
         if ($until instanceof \DateTime) {
             $params['until'] = Granularity::formatDate($until, $this->getGranularity());
-        } elseif (null !== $from) {
+        } elseif (null !== $until) {
             trigger_error(sprintf(
                 'Deprecated: %s::%s \'until\' parameter should be an instance of \DateTime (string param support to be removed in v3.0)',
                 get_called_class(),


### PR DESCRIPTION
There was an bug causing the error message `Deprecated: Phpoaipmh\Endpoint::listRecords 'until' parameter should be an instance of \DateTime (string param support to be removed in v3.0)` if "until" parameter was set to NULL.