### PR TITLE
Support query parameters in endpoint URL

### DIFF
--- a/src/Phpoaipmh/Client.php
+++ b/src/Phpoaipmh/Client.php
@@ -93,7 +93,7 @@ class Client
 
         //Build the URL
         $params = array_merge(array('verb' => $verb), $params);
-        $url = $this->url . '?' . http_build_query($params);
+        $url = $this->url . (parse_url($this->url, PHP_URL_QUERY) ? '&' : '?') . http_build_query($params);
 
         //Do the request
         try {


### PR DESCRIPTION
Will make sure that the OAI parameters are appended with the right character (`&` when there are already parameters in the endpoint URL).