### PR TITLE
#26 Fix namespace lack for children.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "caseyamcl/phpoaipmh",
+    "name": "naoned/phpoaipmh",
     "type": "library",
     "description": "A PHP OAI-PMH 2.0 Harvester library",
     "keywords": ["OAI", "Harvester", "OAI-PMH"],

--- a/src/Phpoaipmh/RecordIterator.php
+++ b/src/Phpoaipmh/RecordIterator.php
@@ -167,8 +167,7 @@ class RecordIterator implements \Iterator
         if (count($this->batch) > 0) {
             $this->numProcessed++;
 
-            $item = array_shift($this->batch);
-            $this->currItem = new \SimpleXMLElement($item->asXML());
+            $this->currItem = array_shift($this->batch);
         } else {
             $this->currItem = false;
         }

--- a/src/Phpoaipmh/RecordIterator.php
+++ b/src/Phpoaipmh/RecordIterator.php
@@ -167,7 +167,19 @@ class RecordIterator implements \Iterator
         if (count($this->batch) > 0) {
             $this->numProcessed++;
 
-            $this->currItem = array_shift($this->batch);
+            $item = array_shift($this->batch);
+            $namespaceAttributes = '';
+            // Add all namespaces until current node, in order to properly create new SimpleXMLElement
+            foreach ($item->getNamespaces(true) as $namespaceName => $namespaceValue) {
+                $namespaceName = $namespaceName ? ':'.$namespaceName : '';
+                $namespaceAttributes .= ' xmlns'.$namespaceName.'="'.$namespaceValue.'"';
+            }
+            $xmlStr = $item->asXML();
+            if ($namespaceAttributes) {
+                $pos = strpos($xmlStr, '>');
+                $xmlStr = substr($xmlStr, 0, $pos).$namespaceAttributes.substr($xmlStr, $pos);
+            }
+            $this->currItem = new \SimpleXMLElement($xmlStr);
         } else {
             $this->currItem = false;
         }


### PR DESCRIPTION
Sorry for dirtey code (work on strings), but it seems SimpleXML does not allow us to add namespace definition. Its addAttribute method remove anything before «:».