### PR TITLE
Namespaces declared in parent elements of OAI response get lost

### DIFF
--- a/src/Phpoaipmh/RecordIterator.php
+++ b/src/Phpoaipmh/RecordIterator.php
@@ -168,7 +168,7 @@ class RecordIterator implements \Iterator
             $this->numProcessed++;
 
             $item = array_shift($this->batch);
-            $this->currItem = new \SimpleXMLElement($item->asXML());
+            $this->currItem = $item;
         } else {
             $this->currItem = false;
         }

--- a/src/Phpoaipmh/RecordIterator.php
+++ b/src/Phpoaipmh/RecordIterator.php
@@ -168,7 +168,7 @@ class RecordIterator implements \Iterator
             $this->numProcessed++;
 
             $item = array_shift($this->batch);
-            $this->currItem = $item;
+            $this->currItem = clone $item;
         } else {
             $this->currItem = false;
         }


### PR DESCRIPTION
I think, I found an issue with the way method nextItem() copies/extracts the single "item subtrees" from the original OAI XML response document: Namespace declarations in parent elements of $item get lost when doing new \SimpleXMLElement($item->asXML()) though the original $item SimpleXMLElement object instance has them. By cloning the $item SimpleXMLElement instance this information is kept and returned by nextItem().
I noticed the problem when harvesting data from DOAJ, and got warnings of undeclared namespaces from RecordIterator.php. Consequently I had invalid XML documents after inserting the SimpleXMLElement object instances returned by nextItem() into new XML documents.