### PR TITLE
Added resumptionToken argument to allow imports to continue a previous import.

### DIFF
--- a/src/Phpoaipmh/Endpoint.php
+++ b/src/Phpoaipmh/Endpoint.php
@@ -138,14 +138,15 @@ class Endpoint implements EndpointInterface
      * Corresponds to OAI Verb to list record identifiers
      *
      * @param  string         $metadataPrefix Required by OAI-PMH endpoint
-     * @param  \DateTime      $from           An optional 'from' date for selective harvesting
-     * @param  \DateTime      $until          An optional 'until' date for selective harvesting
-     * @param  string         $set            An optional setSpec for selective harvesting
+     * @param  \DateTime      $from             An optional 'from' date for selective harvesting
+     * @param  \DateTime      $until            An optional 'until' date for selective harvesting
+     * @param  string         $set              An optional setSpec for selective harvesting
+     * @param  string         $resumptionToken  An optional resumptionToken for selective harvesting
      * @return RecordIterator
      */
-    public function listIdentifiers($metadataPrefix, $from = null, $until = null, $set = null)
+    public function listIdentifiers($metadataPrefix, $from = null, $until = null, $set = null, $resumptionToken = null)
     {
-        return $this->createRecordIterator("ListIdentifiers", $metadataPrefix, $from, $until, $set);
+        return $this->createRecordIterator("ListIdentifiers", $metadataPrefix, $from, $until, $set, $resumptionToken);
     }
 
     // -------------------------------------------------------------------------
@@ -156,14 +157,15 @@ class Endpoint implements EndpointInterface
      * Corresponds to OAI Verb to list records
      *
      * @param  string         $metadataPrefix Required by OAI-PMH endpoint
-     * @param  \DateTime      $from           An optional 'from' date for selective harvesting
-     * @param  \DateTime      $until          An optional 'from' date for selective harvesting
-     * @param  string         $set            An optional setSpec for selective harvesting
+     * @param  \DateTime      $from             An optional 'from' date for selective harvesting
+     * @param  \DateTime      $until            An optional 'from' date for selective harvesting
+     * @param  string         $set              An optional setSpec for selective harvesting
+     * @param  string         $resumptionToken  An optional resumptionToken for selective harvesting
      * @return RecordIterator
      */
-    public function listRecords($metadataPrefix, $from = null, $until = null, $set = null)
+    public function listRecords($metadataPrefix, $from = null, $until = null, $set = null, $resumptionToken = null)
     {
-        return $this->createRecordIterator("ListRecords", $metadataPrefix, $from, $until, $set);
+        return $this->createRecordIterator("ListRecords", $metadataPrefix, $from, $until, $set, $resumptionToken);
     }
 
     // -------------------------------------------------------------------------
@@ -171,15 +173,16 @@ class Endpoint implements EndpointInterface
     /**
      * Create a record iterator
      *
-     * @param  string         $verb           OAI Verb
-     * @param  string         $metadataPrefix Required by OAI-PMH endpoint
-     * @param  \DateTime|null $from           An optional 'from' date for selective harvesting
-     * @param  \DateTime|null $until          An optional 'from' date for selective harvesting
-     * @param  string         $set            An optional setSpec for selective harvesting
+     * @param  string         $verb             OAI Verb
+     * @param  string         $metadataPrefix   Required by OAI-PMH endpoint
+     * @param  \DateTime|null $from             An optional 'from' date for selective harvesting
+     * @param  \DateTime|null $until            An optional 'from' date for selective harvesting
+     * @param  string         $set              An optional setSpec for selective harvesting
+     * @param  string         $resumptionToken  An optional resumptionToken for selective harvesting
      *
      * @return RecordIterator
      */
-    private function createRecordIterator($verb, $metadataPrefix, $from, $until, $set)
+    private function createRecordIterator($verb, $metadataPrefix, $from, $until, $set, $resumptionToken)
     {
         $params = array('metadataPrefix' => $metadataPrefix);
 
@@ -207,7 +210,7 @@ class Endpoint implements EndpointInterface
             $params['set'] = $set;
         }
 
-        return new RecordIterator($this->client, $verb, $params);
+        return new RecordIterator($this->client, $verb, $params, $resumptionToken);
     }
 
     // ---------------------------------------------------------------

--- a/src/Phpoaipmh/EndpointInterface.php
+++ b/src/Phpoaipmh/EndpointInterface.php
@@ -82,9 +82,11 @@ interface EndpointInterface
      *                                        selective harvesting
      * @param  string    $set                 An optional setSpec for selective
      *                                        harvesting
+     * @param  string    $resumptionToken     An optional resumptionToken for selective
+     *                                        harvesting
      * @return RecordIterator
      */
-    public function listIdentifiers($metadataPrefix, $from = null, $until = null, $set = null);
+    public function listIdentifiers($metadataPrefix, $from = null, $until = null, $set = null, $resumptionToken = null);
 
     /**
      * List Records
@@ -98,7 +100,9 @@ interface EndpointInterface
      *                                        selective harvesting
      * @param  string    $set                 An optional setSpec for selective
      *                                        harvesting
+     * @param  string    $resumptionToken     An optional resumptionToken for selective
+     *                                        harvesting
      * @return RecordIterator
      */
-    public function listRecords($metadataPrefix, $from = null, $until = null, $set = null);
+    public function listRecords($metadataPrefix, $from = null, $until = null, $set = null, $resumptionToken = null);
 }

--- a/src/Phpoaipmh/RecordIterator.php
+++ b/src/Phpoaipmh/RecordIterator.php
@@ -87,12 +87,13 @@ class RecordIterator implements \Iterator
      * @param string $verb       The verb to use when retrieving results from the client
      * @param array  $params     Optional parameters passed to OAI-PMH
      */
-    public function __construct(Client $httpClient, $verb, array $params = array())
+    public function __construct(Client $httpClient, $verb, array $params = array(), $resumptionToken = null)
     {
         //Set parameters
-        $this->httpClient = $httpClient;
-        $this->verb       = $verb;
-        $this->params     = $params;
+        $this->httpClient       = $httpClient;
+        $this->verb             = $verb;
+        $this->params           = $params;
+        $this->resumptionToken  = $resumptionToken;
 
         //Node name error?
         if (! $this->getItemNodeName()) {
@@ -299,5 +300,15 @@ class RecordIterator implements \Iterator
     public function rewind()
     {
         $this->reset();
+    }
+
+    public function getBatch()
+    {
+        return $this->batch;
+    }
+
+    public function getResumptionToken()
+    {
+        return $this->resumptionToken;
     }
 }

--- a/tests/Phpoaipmh/EndpointTest.php
+++ b/tests/Phpoaipmh/EndpointTest.php
@@ -179,9 +179,8 @@ class EndpointTest extends PHPUnit_Framework_TestCase
             'from' => "2014-01-01",
             'until' => "2015-01-01",
             'set' => "setSpec",
-            'resumptionToken' => "0/200/733/nsdl_dc/null/2012-07-26/null",
         );
-        $expectedRecordIterator = new RecordIterator($client, "ListIdentifiers", $expectedParams);
+        $expectedRecordIterator = new RecordIterator($client, "ListIdentifiers", $expectedParams, "0/200/733/nsdl_dc/null/2012-07-26/null");
         $this->assertEquals($expectedRecordIterator, $returnValue);
     }
 
@@ -217,9 +216,8 @@ class EndpointTest extends PHPUnit_Framework_TestCase
             'from' => "2014-01-01",
             'until' => "2015-01-01",
             'set' => "setSpec",
-            'resumptionToken' => "0/200/733/nsdl_dc/null/2012-07-26/null",
         );
-        $expectedRecordIterator = new RecordIterator($client, "ListRecords", $expectedParams);
+        $expectedRecordIterator = new RecordIterator($client, "ListRecords", $expectedParams, "0/200/733/nsdl_dc/null/2012-07-26/null");
         $this->assertEquals($expectedRecordIterator, $returnValue);
     }
 

--- a/tests/Phpoaipmh/EndpointTest.php
+++ b/tests/Phpoaipmh/EndpointTest.php
@@ -172,13 +172,14 @@ class EndpointTest extends PHPUnit_Framework_TestCase
         $client = $this->getMockClient();
         $obj = new Endpoint($client);
 
-        $returnValue = $obj->listIdentifiers("metadataPrefix", new \DateTime("2014-01-01"), new \DateTime("2015-01-01"), "setSpec");
+        $returnValue = $obj->listIdentifiers("metadataPrefix", new \DateTime("2014-01-01"), new \DateTime("2015-01-01"), "setSpec", "0/200/733/nsdl_dc/null/2012-07-26/null");
 
         $expectedParams = array(
             'metadataPrefix' => "metadataPrefix",
             'from' => "2014-01-01",
             'until' => "2015-01-01",
             'set' => "setSpec",
+            'resumptionToken' => "0/200/733/nsdl_dc/null/2012-07-26/null",
         );
         $expectedRecordIterator = new RecordIterator($client, "ListIdentifiers", $expectedParams);
         $this->assertEquals($expectedRecordIterator, $returnValue);
@@ -209,13 +210,14 @@ class EndpointTest extends PHPUnit_Framework_TestCase
         $client = $this->getMockClient();
         $obj = new Endpoint($client);
 
-        $returnValue = $obj->listRecords("metadataPrefix", new \DateTime("2014-01-01"), new \DateTime("2015-01-01"), "setSpec");
+        $returnValue = $obj->listRecords("metadataPrefix", new \DateTime("2014-01-01"), new \DateTime("2015-01-01"), "setSpec", "0/200/733/nsdl_dc/null/2012-07-26/null");
 
         $expectedParams = array(
             'metadataPrefix' => "metadataPrefix",
             'from' => "2014-01-01",
             'until' => "2015-01-01",
             'set' => "setSpec",
+            'resumptionToken' => "0/200/733/nsdl_dc/null/2012-07-26/null",
         );
         $expectedRecordIterator = new RecordIterator($client, "ListRecords", $expectedParams);
         $this->assertEquals($expectedRecordIterator, $returnValue);


### PR DESCRIPTION
Hi,

Thanks for your awesome work. While working on a very large import it seemed nice to be able to allow batches of records in stead of importing everything at once. The applications keeps tracks of the resumptionToken and stores it locally. When doing the next batch, we start at the last known resumptionToken.

For this to work I've added the resumptionToken as an argument for ListRecords and ListIdentifiers (and off course to the RecordIterator). I've also added public methods to fetch the resumptionToken and the current batch, since we need the batch to determine when we want to store the new resumptionToken.

Would you consider adding this?

By the way, I've used this library to create a migration provider for Drupal (https://www.drupal.org/project/migrate_oaipmh). The Drupal migrate module allows for batch imports, so that was the main reason to start this. But I think it would make sense in other cases as well.