### PR TITLE
Fix compatibility with PHP 7.4 by removing curly brace usage

### DIFF
--- a/src/HttpAdapter/CurlAdapter.php
+++ b/src/HttpAdapter/CurlAdapter.php
@@ -78,7 +78,7 @@ class CurlAdapter implements HttpAdapterInterface
 
         //Check response
         $httpCode = (string) $info->http_code;
-        if ($httpCode{0} != '2') {
+        if ($httpCode[0] != '2') {
             $msg = sprintf('HTTP Request Failed (code %s): %s', $info->http_code, $resp);
             throw new HttpException($resp, $msg, $httpCode);
         } elseif (strlen(trim($resp)) == 0) {


### PR DESCRIPTION
Curly brace syntax for accessing array elements and string offsets has been deprecated in PHP 7.4