### PR TITLE
fix: reset batch array

### DIFF
--- a/src/RecordIterator.php
+++ b/src/RecordIterator.php
@@ -250,6 +250,7 @@ class RecordIterator implements Iterator, RecordIteratorInterface
         }
 
         //Process the results
+        $this->batch = [];
         foreach ($resp->$verb->$nodeName as $node) {
             $this->batch[] = $node;
         }


### PR DESCRIPTION
I think I found a small bug. The batch array should be reset before filled. Otherwise it will grow bigger and bigger. The return value is also not as expected.

Edit: This applies for consecutive calls of retrieveNextBatch() without using Iterator methods