### PR TITLE
Prevent deprecation errors on PHP8+

### DIFF
--- a/src/RecordIterator.php
+++ b/src/RecordIterator.php
@@ -319,6 +319,7 @@ class RecordIterator implements Iterator, RecordIteratorInterface
     // ----------------------------------------------------------------
     // Iterator methods
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return ($this->currItem === null)
@@ -326,11 +327,13 @@ class RecordIterator implements Iterator, RecordIteratorInterface
             : $this->currItem;
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         return $this->nextItem();
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         if ($this->currItem === null) {
@@ -340,11 +343,13 @@ class RecordIterator implements Iterator, RecordIteratorInterface
         return $this->getNumRetrieved();
     }
 
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return ($this->currItem !== false);
     }
 
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->reset();


### PR DESCRIPTION
I'm using this library with [Drupal](https://www.drupal.org/) [OAI-PMH Harvester module](https://www.drupal.org/project/oai_pmh_harvester).
When I run a harvest action I got some PHP deprecation errors.

`Deprecated function: Return type of Phpoaipmh\RecordIterator::current() should either be compatible with Iterator::current(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in include() (line 33 of vendor/caseyamcl/phpoaipmh/src/RecordIterator.php).`

`Deprecated function: Return type of Phpoaipmh\RecordIterator::next() should either be compatible with Iterator::next(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in include() (line 33 of vendor/caseyamcl/phpoaipmh/src/RecordIterator.php).`

`Deprecated function: Return type of Phpoaipmh\RecordIterator::key() should either be compatible with Iterator::key(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in include() (line 33 of vendor/caseyamcl/phpoaipmh/src/RecordIterator.php).`

`Deprecated function: Return type of Phpoaipmh\RecordIterator::valid() should either be compatible with Iterator::valid(): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in include() (line 33 of vendor/caseyamcl/phpoaipmh/src/RecordIterator.php).`

`Deprecated function: Return type of Phpoaipmh\RecordIterator::rewind() should either be compatible with Iterator::rewind(): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in include() (line 33 of vendor/caseyamcl/phpoaipmh/src/RecordIterator.php).`